### PR TITLE
partially enabled searching for embedded resources by secondary key for #8

### DIFF
--- a/test/json_hal.js
+++ b/test/json_hal.js
@@ -355,6 +355,27 @@ describe('The JSON-HAL walker\'s', function() {
       );
     });
 
+    it('should pass matched embedded document from the array into the ' +
+        'callback', function(done) {
+      api
+        .newRequest()
+        .follow('ea:orders', 'ea:order[total:20.00]')
+        .get(callback);
+      waitFor(
+        function() { return callback.called; },
+        function() {
+          var error = callback.firstCall.args[0];
+          expect(error).to.not.exist;
+          var response = callback.firstCall.args[1];
+          expect(response).to.exist;
+          expect(response.body).to.equal(embeddedOrderResponses[1].body);
+          expect(response.statusCode).to.equal(200);
+          expect(response.remark).to.exist;
+          done();
+        }
+      );
+    });
+
     it('should follow first embedded resource from an array automatically',
         function(done) {
       api


### PR DESCRIPTION
This is only a partial solution as the test data makes it very difficult to test this independently of the other tests. This is enough to satisfy my use case as it does seem to follow the link from the embedded resource rather than return the resource as embedded.

 Obviously, I don't expect this to be merged in as-is, but I am hoping that this can either help you make a similar change independently or start a thread where we could work together to get this to a state that would be acceptable for a merge.