### PR TITLE
Make $all sensible for single embedded results

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,8 @@ function findLink(ctx, log) {
     case 'first':
       findLinkWithoutIndex(ctx, linkArray, log);
       break;
+    case 'all':
+      break;  // fall through to embedded path
     default:
       throw new Error('Illegal mode: ' + ctx.parsedKey.mode);
   }

--- a/index.js
+++ b/index.js
@@ -193,7 +193,8 @@ function findEmbedded(ctx, log) {
       (ctx.parsedKey.index ? ctx.parsedKey.index : ''));
 
   var resourceArray = ctx.halResource.embeddedArray(ctx.parsedKey.key);
-  if (!resourceArray || resourceArray.length === 0) {
+  if ((!resourceArray || resourceArray.length === 0) &&
+       ctx.parsedKey.mode !== 'all' ) {
     return null;
   }
   log.debug('Found an array of embedded resource for: ' + ctx.parsedKey.key);
@@ -256,7 +257,9 @@ function findEmbeddedAll(ctx, embeddedArray, log) {
   // but it holds halfred objects, and other tests freak out.
   // var result = embeddedArray;
   var result = ctx.halResource.original()._embedded[ctx.parsedKey.key];
-  if (! (result instanceof Array)) { // Array.isArray(result)
+  if (! result) {
+    result = [];
+  } else if (! (result instanceof Array)) { // Array.isArray(result)
     result = [].concat(result);
   }
   

--- a/index.js
+++ b/index.js
@@ -256,7 +256,8 @@ function findEmbeddedAll(ctx, embeddedArray, log) {
   // I'd rather just use the embedded array,
   // but it holds halfred objects, and other tests freak out.
   // var result = embeddedArray;
-  var result = ctx.halResource.original()._embedded[ctx.parsedKey.key];
+  var result = ctx.halResource.original()._embedded &&
+      ctx.halResource.original()._embedded[ctx.parsedKey.key];
   if (! result) {
     result = [];
   } else if (! (result instanceof Array)) { // Array.isArray(result)

--- a/test/hal_docs.js
+++ b/test/hal_docs.js
@@ -73,7 +73,9 @@ module.exports = {
         'name': 'boss'
       }, {
         'name': 'no-href'
-      }]
+      }],
+      'ea:link_and_embedded_admin': embeddedAdmins[0]._links.self
+
     },
     'currentlyProcessing': 14,
     'shippedToday': 20,
@@ -81,7 +83,8 @@ module.exports = {
       'ea:order': embeddedOrders,
       'ea:admin': embeddedAdmins, // to test preferEmbedded
       // to test $all with a single object
-      'ea:single_embedded_admin': embeddedAdmins[0]
+      'ea:single_embedded_admin': embeddedAdmins[0],
+      'ea:link_and_embedded_admin': embeddedAdmins[0]
     }
   },
 

--- a/test/json_hal.js
+++ b/test/json_hal.js
@@ -630,6 +630,25 @@ describe('The JSON-HAL walker\'s', function() {
       );
     });
 
+    it('should return embeddeds when shadowing link if using $all',
+        function(done) {
+      api
+      .newRequest()
+      .follow('ea:orders', 'ea:link_and_embedded_admin[$all]')
+      .getResource(callback);
+      waitFor(
+        function() { return callback.called; },
+        function() {
+          var error = callback.firstCall.args[0]; 
+          var doc = callback.firstCall.args[1];
+          expect(error).to.not.exist;
+          expect(doc).to.eql(
+            [ ordersDoc._embedded['ea:link_and_embedded_admin'] ]);
+          done();
+        }
+      );
+    });
+
     it('should yield an empty array when $all accessed on missing embedded',
         function(done) {
       api

--- a/test/json_hal.js
+++ b/test/json_hal.js
@@ -630,6 +630,24 @@ describe('The JSON-HAL walker\'s', function() {
       );
     });
 
+    it('should yield an empty array when $all accessed on missing embedded',
+        function(done) {
+      api
+      .newRequest()
+      .follow('ea:orders', 'ea:no_such_rel[$all]')
+      .getResource(callback);
+      waitFor(
+        function() { return callback.called; },
+        function() {
+          var error = callback.firstCall.args[0]; 
+          var doc = callback.firstCall.args[1];
+          expect(error).to.not.exist;
+          expect(doc).to.eql([]);
+          done();
+        }
+      );
+        });
+    
     it('should pass an embedded document into the callback',
         function(done) {
       api


### PR DESCRIPTION
$all currently returns a bare object if the source HAL doc has single embedded resource rather than an array with 1 element.  This patch changes that behaviour.
